### PR TITLE
Activate relative assets

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -8,6 +8,7 @@ configure :build do
   activate :minify_css
   activate :minify_javascript
   activate :asset_hash
+  activate :relative_assets
 
   # Only Including Tracking Code in Builds
   activate :google_analytics do |ga|


### PR DESCRIPTION
We need to have assets linked relatively to be able to host generated
content as http://fs.github.io/static-base
